### PR TITLE
Fix Entropy Detector Nan values

### DIFF
--- a/src/pytorch_ood/detector/entropy.py
+++ b/src/pytorch_ood/detector/entropy.py
@@ -77,5 +77,5 @@ class Entropy(Detector):
         """
         :param logits: logits of input
         """
-        p = logits.softmax(dim=1)
+        p = logits.softmax(dim=1).clip(1e-7, 1)
         return -(p.log() * p).sum(dim=1)


### PR DESCRIPTION
Solve NaN values from Entropy detector (https://github.com/kkirchheim/pytorch-ood/issues/84) by clipping softmax output between 1e-7 and 1