### PR TITLE
docs: fix arxiv link, temperatur -> temperature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ The package can be installed via PyPI:
 +-----------------------------+------------------------------------------------------------------------------------------------+------+--------------------+
 | Maximum Softmax Probability | Implements the Softmax Baseline for OOD and Error detection.                                   | 2017 | [#Softmax]_        |
 +-----------------------------+------------------------------------------------------------------------------------------------+------+--------------------+
-| Temperature Scaling         | Implements the Temperatur Scaling for Softmax.                                                 | 2017 | [#TempScaling]_    |
+| Temperature Scaling         | Implements the Temperature Scaling for Softmax.                                                 | 2017 | [#TempScaling]_    |
 +-----------------------------+------------------------------------------------------------------------------------------------+------+--------------------+
 | ODIN                        | ODIN is a preprocessing method for inputs that aims to increase the discriminability of        | 2018 | [#ODIN]_           |
 |                             | the softmax outputs for In- and Out-of-Distribution data.                                      |      |                    |

--- a/src/pytorch_ood/detector/maxlogit.py
+++ b/src/pytorch_ood/detector/maxlogit.py
@@ -29,7 +29,7 @@ class MaxLogit(Detector):
     where :math:`f_y(x)` indicates the :math:`y^{th}` logits value predicted by :math:`f`.
 
     :see Paper:
-       `ArXiv <https://.org/abs/1911.11132>`__
+       `ArXiv <https://arxiv.org/abs/1911.11132>`__
     """
 
     def __init__(self, model: Module):


### PR DESCRIPTION
Hello! 

I spotted a broken link in the docs (it just went to `.org` instead of `arxiv.org`). I checked other links, but all others seemed to be in order. I also fixed a typo in the README.