### PR TITLE
Fix inverted sign convention in RankFeat

### DIFF
--- a/src/pytorch_ood/detector/rankfeat.py
+++ b/src/pytorch_ood/detector/rankfeat.py
@@ -114,4 +114,4 @@ class RankFeat(FeatureMapsDetector):
     def predict_feature_maps(self, x: Tensor) -> Tensor:
         x = _remove_rank1(x)
         x = self.head(x)
-        return -self.detector(x)
+        return self.detector(x)

--- a/tests/detectors/test_rankfeat.py
+++ b/tests/detectors/test_rankfeat.py
@@ -136,6 +136,28 @@ class TestRankFeat(unittest.TestCase):
             "RankFeat scores should differ from plain energy scores",
         )
 
+    def test_score_matches_energy_convention(self):
+        """
+        Regression test for the sign convention: the default detector (EnergyBased.score)
+        already follows this library's convention of higher-score-means-more-OOD (see
+        EnergyBased's docstring), so predict_feature_maps must not negate it again. A past
+        version of this file did `return -self.detector(x)`, which silently inverted every
+        AUROC computed with RankFeat's default scoring function.
+        """
+        model = SimpleCNN(num_classes=3).eval()
+        detector = RankFeat(backbone=model.backbone, head=model.head)
+
+        x = torch.randn(8, 3, 8, 8)
+        with torch.no_grad():
+            scores = detector(x)
+            z = _remove_rank1(model.backbone(x))
+            logits = model.head(z)
+            from src.pytorch_ood.detector import EnergyBased
+
+            expected = EnergyBased.score(logits)
+
+        self.assertTrue(torch.allclose(scores, expected, atol=1e-5))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `RankFeat.predict_feature_maps` negated the default detector's score (`EnergyBased.score`), which already follows this library's convention of higher-score-means-more-OOD (unlike `RankFeat`, `ReAct`/`ASH`/`SCALE`/`VRA` all return the detector's score unmodified).
- This silently inverted every AUROC computed with RankFeat's default scoring function (observed AUROC ~38 instead of ~85 on CIFAR-100 OpenOOD).
- Added a regression test pinning `RankFeat`'s output to `EnergyBased.score` on the rank-1-reduced logits, so a reintroduced sign flip fails immediately.

## Test plan
- [x] `python -m unittest tests.detectors.test_rankfeat -v` passes
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)