### PR TITLE
Fix GEN score saturating AUROC to ~0.5 on many-class datasets

### DIFF
--- a/src/pytorch_ood/detector/gen.py
+++ b/src/pytorch_ood/detector/gen.py
@@ -41,6 +41,11 @@ class GEN(LogitsDetector):
     uses :math:`M = 100` for ImageNet) discards the noisy near-zero tail, which the power
     transform would otherwise amplify; for small label spaces it has little effect.
 
+    .. note::
+        This implementation averages over the top-:math:`M` terms instead of summing, which
+        rescales the score by a constant factor (no effect on AUROC/AUPR) but keeps it bounded
+        regardless of class count — avoiding float32 saturation in torchmetrics' ``binary_auroc``.
+
     A small :math:`\\gamma` (the paper recommends :math:`\\gamma = 0.1`) amplifies differences
     near :math:`p = 0` and :math:`p = 1`, making the score highly sensitive to the shape of
     the (truncated) softmax distribution rather than only its maximum. In-distribution samples
@@ -92,4 +97,5 @@ class GEN(LogitsDetector):
         if M is not None:
             # keep the M largest probabilities per sample (top-M classes)
             p = p.sort(dim=1, descending=True).values[:, :M]
-        return (p.pow(gamma) * (1 - p).pow(gamma)).sum(dim=1)
+        # mean, not sum, to keep the score bounded regardless of class count (see class docstring)
+        return (p.pow(gamma) * (1 - p).pow(gamma)).mean(dim=1)

--- a/tests/detectors/test_gen.py
+++ b/tests/detectors/test_gen.py
@@ -95,9 +95,9 @@ class TestGEN(unittest.TestCase):
         # Different gammas should produce different scores
         self.assertFalse(torch.allclose(scores_01, scores_05))
 
-        # gamma=1 should give sum of p*(1-p), i.e. Gini impurity
+        # gamma=1 should give mean of p*(1-p), i.e. average Gini impurity
         p = logits.softmax(dim=1)
-        expected_gini = (p * (1 - p)).sum(dim=1)
+        expected_gini = (p * (1 - p)).mean(dim=1)
         scores_1 = GEN.score(logits, gamma=1.0)
         self.assertTrue(torch.allclose(scores_1, expected_gini, atol=1e-6))
 
@@ -115,7 +115,7 @@ class TestGEN(unittest.TestCase):
 
         p = logits.softmax(dim=1).clamp(1e-7, 1 - 1e-7)
         top = p.sort(dim=1, descending=True).values[:, :M]
-        expected = (top.pow(gamma) * (1 - top).pow(gamma)).sum(dim=1)
+        expected = (top.pow(gamma) * (1 - top).pow(gamma)).mean(dim=1)
 
         self.assertTrue(torch.allclose(scores, expected, atol=1e-6))
         # truncation changes the score relative to using all classes
@@ -149,6 +149,42 @@ class TestGEN(unittest.TestCase):
         with torch.no_grad():
             for x, y in DataLoader(TensorDataset(x_id, y_id), batch_size=64):
                 metrics.update(detector(x), y)
+            for x, y in DataLoader(TensorDataset(x_ood, y_ood), batch_size=64):
+                metrics.update(detector(x), y)
+
+        results = metrics.compute()
+        self.assertGreater(
+            results["AUROC"], 0.90, f"Expected AUROC > 0.90, got {results['AUROC']:.4f}"
+        )
+
+    def test_mock_performance_many_classes(self):
+        """
+        Regression test: with M=None, the score is computed over all classes. For datasets
+        with many classes (e.g. CIFAR-100, ImageNet), a naive sum grows past 1.0. OODMetrics
+        (via torchmetrics' binary_auroc) silently applies a sigmoid to scores outside [0, 1],
+        which saturates to 1.0 in float32 for such magnitudes and collapses AUROC to ~0.5.
+        Verifies the score stays bounded and AUROC remains high with 100 classes.
+        """
+        torch.manual_seed(42)
+        # n_dim >= n_classes: _make_id_ood_data's one-hot-style centers need at least one
+        # dimension per class to stay separated.
+        n_dim, n_classes, n_per_class = 100, 100, 10
+
+        x_id, y_id, x_ood, y_ood = _make_id_ood_data(
+            n_dim=n_dim, n_classes=n_classes, n_per_class=n_per_class
+        )
+
+        model = ClassificationModel(num_inputs=n_dim, num_outputs=n_classes, n_hidden=64)
+        _train_model(model, x_id, y_id, epochs=300)
+
+        detector = GEN(model)
+
+        metrics = OODMetrics()
+        with torch.no_grad():
+            for x, y in DataLoader(TensorDataset(x_id, y_id), batch_size=64):
+                scores = detector(x)
+                self.assertTrue((scores <= 1.0).all(), "GEN scores should stay within [0, 1]")
+                metrics.update(scores, y)
             for x, y in DataLoader(TensorDataset(x_ood, y_ood), batch_size=64):
                 metrics.update(detector(x), y)
 


### PR DESCRIPTION
## Summary
- `GEN.score` summed the power-transform term over all classes (per the paper), reaching magnitudes of ~20-50 for 100-class datasets like CIFAR-100.
- `OODMetrics` computes AUROC via torchmetrics' `binary_auroc`, which silently applies `sigmoid()` to any score outside `[0, 1]`; at that magnitude `sigmoid()` saturates to `1.0` in float32 for virtually every sample, collapsing the ranking (observed AUROC ~50 instead of ~80 on CIFAR-100 OpenOOD).
- Changed `sum` to `mean`: since the divisor (`M`, or the class count) is constant across a batch, this only rescales the score and leaves AUROC/AUPR rankings unchanged, while keeping scores bounded to roughly `[0, 1]` regardless of class count.
- Added a regression test with 100 synthetic classes verifying scores stay bounded and AUROC stays high.

## Test plan
- [x] `python -m unittest tests.detectors.test_gen -v` passes
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)