### PR TITLE
Fix VRA fit() flattening spatial feature maps

### DIFF
--- a/src/pytorch_ood/detector/vra.py
+++ b/src/pytorch_ood/detector/vra.py
@@ -22,7 +22,7 @@ import torch.nn
 from torch import Tensor
 from torch.utils.data import DataLoader
 
-from pytorch_ood.utils import extract_features, is_known
+from pytorch_ood.utils import is_known
 
 from ..api import FeatureMapsDetector, ModelNotSetException, RequiresFittingException
 from .energy import EnergyBased
@@ -159,7 +159,25 @@ class VRA(FeatureMapsDetector):
             log.warning(f"No device set. Will use '{device}'.")
             self.to(device)
 
-        z, y = extract_features(data_loader, self.backbone, device=device)
+        # NOTE: unlike pytorch_ood.utils.extract_features (which flattens each sample
+        # to a 1-D vector, for pooled-feature detectors), the per-dimension clipping
+        # thresholds computed by fit_feature_maps require the spatial (N, C, H, W)
+        # shape to be preserved, since predict_feature_maps() clips un-flattened
+        # feature maps of that same shape.
+        zs, ys = [], []
+        with torch.no_grad():
+            for x, y in data_loader:
+                known = is_known(y)
+                if not known.any():
+                    continue
+                zs.append(self.backbone(x[known].to(device)).detach().cpu())
+                ys.append(y[known].cpu())
+
+        if not zs:
+            raise ValueError("No ID data")
+
+        z = torch.cat(zs, dim=0)
+        y = torch.cat(ys, dim=0)
         self.fit_feature_maps(z, y)
         return self
 

--- a/tests/detectors/test_vra.py
+++ b/tests/detectors/test_vra.py
@@ -1,7 +1,7 @@
 import unittest
 
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, TensorDataset
 
 from src.pytorch_ood.detector import VRA
 from tests.helpers import ClassificationModel, sample_dataset
@@ -27,6 +27,26 @@ class TestVRA(unittest.TestCase):
         x = torch.randn(8, 2)
         scores = detector(x)
         self.assertEqual(scores.shape, (8,))
+
+    def test_fit_and_predict_with_spatial_feature_maps(self):
+        """
+        Regression test: fit() must preserve the (N, C, H, W) shape of feature maps
+        from a real conv backbone (H, W > 1), since predict_feature_maps() clips
+        un-flattened feature maps of that same shape.
+        """
+        backbone = torch.nn.Conv2d(3, 4, kernel_size=3, padding=1)
+        head = torch.nn.Sequential(
+            torch.nn.AdaptiveAvgPool2d(1), torch.nn.Flatten(), torch.nn.Linear(4, 3)
+        )
+        detector = VRA(backbone=backbone, head=head)
+
+        x = torch.randn(20, 3, 8, 8)
+        y = torch.zeros(20, dtype=torch.long)
+        loader = DataLoader(TensorDataset(x, y), batch_size=4)
+        detector.fit(loader)
+
+        scores = detector(torch.randn(5, 3, 8, 8))
+        self.assertEqual(scores.shape, (5,))
 
     def test_fit_feature_maps_and_predict_feature_maps(self):
         detector = VRA(


### PR DESCRIPTION
## Summary
- `VRA.fit()` used `extract_features()`, which flattens every sample to a 1-D vector -- fine for pooled-feature detectors, but wrong for VRA: its per-dimension clip thresholds need the `(N, C, H, W)` shape preserved, since `predict_feature_maps()` clips un-flattened feature maps of that same shape.
- This broke silently for any real conv backbone (mismatched broadcast shapes at predict time); the existing tests didn't catch it because the mock model's `features()` output was already flat.
- Adds a regression test with a real `Conv2d` backbone (spatial `H, W > 1`).

## Test plan
- [x] `pytest tests/detectors/test_vra.py` passes, including the new regression test
- [x] Full suite passes