### PR TITLE
Add hyperparameter_space to VRA for GridSearch/HPO

### DIFF
--- a/src/pytorch_ood/detector/vra.py
+++ b/src/pytorch_ood/detector/vra.py
@@ -61,6 +61,13 @@ class VRA(FeatureMapsDetector):
 
     requires_fit = True
 
+    #: grid explored by :class:`pytorch_ood.utils.GridSearch`, matching the sweep used
+    #: by the OpenOOD reference implementation (``percentile_high``/``percentile_low``)
+    hyperparameter_space = {
+        "upper_percentile": [85.0, 90.0, 95.0, 99.0],
+        "lower_percentile": [1.0, 5.0, 10.0, 15.0],
+    }
+
     def __init__(
         self,
         backbone: Callable[[Tensor], Tensor],


### PR DESCRIPTION
## Summary
- Adds a `hyperparameter_space` grid to `VRA` (`upper_percentile`, `lower_percentile`) so it's tunable via `pytorch_ood.utils.GridSearch`.
- Values match the sweep used by the OpenOOD reference implementation (`percentile_high`/`percentile_low`).

Depends on nothing else -- independent of #156 (the VRA `fit()` shape fix), just adds the tuning grid on top of the existing behavior.

## Test plan
- [x] `pytest tests/detectors/test_vra.py` passes