### PR TITLE
Fix PNML pinv() blowing up at ImageNet-1K scale

### DIFF
--- a/src/pytorch_ood/detector/pnml.py
+++ b/src/pytorch_ood/detector/pnml.py
@@ -111,8 +111,13 @@ class PNML(FeaturesDetector):
         z = z[known].detach().to(target_device).float()
         z = torch.nn.functional.normalize(z, p=2, dim=1)
 
-        x_pinv = torch.linalg.pinv(z)
-        self._feature_projector = x_pinv @ x_pinv.T
+        # X^+ (X^+)^T == pinv(X^T X) for any X, and equals (X^T X)^{-1} exactly whenever
+        # X^T X is invertible (the practically-always-true case for real feature data).
+        # Computing it this way -- pinv on the small (D, D) Gram matrix -- instead of
+        # pinv(X) directly avoids an SVD over the full (N, D) training-feature matrix,
+        # which is intractable at full-dataset scale (e.g. N=1.28M for ImageNet-1K)
+        # even though D is typically just a few thousand.
+        self._feature_projector = torch.linalg.pinv(z.T @ z)
         self._log_num_classes = None
         return self
 


### PR DESCRIPTION
## Summary
- `fit_features()` computed `torch.linalg.pinv(z)` -- an SVD -- directly over the full `(N, D)` training-feature matrix. Fine at CIFAR/ImageNet-200 scale, but at ImageNet-1K's 1.28M rows it exceeds cuSOLVER's limits and crashes with `CUSOLVER_STATUS_INVALID_VALUE`.
- `X^+ (X^+)^T == pinv(X^T X)` for any `X`, and equals `(X^T X)^{-1}` exactly whenever `X^T X` is invertible (the practically-always-true case for real feature data). Computing it via the small `(D, D)` Gram matrix instead avoids ever running an SVD over an N-sized matrix, while giving the identical result.

Verified numerically equivalent to the original formula (max abs diff ~4e-10 on synthetic data), and reproduces + fixes the actual crash at ImageNet-1K's real scale (1,281,167 x 2048): the old code crashes, the new code fits in ~9s.

## Test plan
- [x] `pytest tests/detectors/test_pnml.py` passes (includes an exact paper-formula comparison test)
- [x] Full suite passes