### PR TITLE
Add training script support for VOSRegLoss

### DIFF
--- a/scripts/configs/loss/vos.yaml
+++ b/scripts/configs/loss/vos.yaml
@@ -1,0 +1,8 @@
+_target_: pytorch_ood.loss.VOSRegLoss
+method_name: vos
+alpha: 0.1
+device: ${device}
+# logistic_regression / weights_energy are built in train.py, since weights_energy
+# needs a non-default nn.init and a dataset.num_classes-sized input -- nesting them
+# here would need a ${dataset.num_classes} interpolation two levels deep, which
+# instantiate_without's node dict can't resolve

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
 CIFAR_DATASETS = {"cifar10": CIFAR10, "cifar100": CIFAR100}
 
 # training methods that require an auxiliary outlier dataset
-REQUIRES_OUTLIERS = {"oe", "energy", "entropic"}
+REQUIRES_OUTLIERS = {"oe", "energy", "entropic", "vos"}
 
 
 def set_seed(seed: int, deterministic: bool) -> None:
@@ -176,8 +176,22 @@ def main(cfg: DictConfig) -> None:
         log.info(f"Initializing weights from '{cfg.init_from}'")
         model.load_state_dict(load_model(cfg.init_from).state_dict())
 
-    criterion = instantiate_without(cfg.loss, "method_name").to(device)
-    optimizer = instantiate(cfg.optimizer, params=model.parameters())
+    criterion_kwargs: Dict[str, Any] = {}
+    if method == "vos":
+        weights_energy = torch.nn.Linear(cfg.dataset.num_classes, 1)
+        # per the VOSRegLoss docstring: the energy re-weighting must start
+        # non-negative, since it is passed through relu() before use
+        torch.nn.init.uniform_(weights_energy.weight)
+        criterion_kwargs = {
+            "logistic_regression": torch.nn.Linear(1, 2),
+            "weights_energy": weights_energy,
+        }
+    criterion = instantiate_without(cfg.loss, "method_name", **criterion_kwargs).to(device)
+    # some losses (e.g. VOSRegLoss) carry their own learnable parameters (the
+    # weighted-energy / logistic-regression heads); include them so they actually train
+    optimizer = instantiate(
+        cfg.optimizer, params=list(model.parameters()) + list(criterion.parameters())
+    )
 
     # OpenOOD's recipe (BaseTrainer, used for every dataset including CIFAR):
     # a LambdaLR cosine schedule stepped once per training iteration (not per
@@ -217,6 +231,9 @@ def main(cfg: DictConfig) -> None:
             best_accuracy = accuracy
             state_dict = {k: v.cpu() for k, v in model.state_dict().items()}
             torch.save(state_dict, output_dir / "model.pt")
+            if criterion_kwargs:
+                criterion_state = {k: v.cpu() for k, v in criterion.state_dict().items()}
+                torch.save(criterion_state, output_dir / "criterion.pt")
 
     metrics = {"final_accuracy": accuracy, "best_accuracy": best_accuracy}
     with open(output_dir / "metrics.json", "w") as f:


### PR DESCRIPTION
## Summary
- New `loss=vos` Hydra config; wired into the outlier-mixing path like `oe`/`energy`/`entropic` since VOS also needs real outliers in the batch.
- `weights_energy`/`logistic_regression` are built directly in `train.py` rather than via nested Hydra instantiation, since `weights_energy` needs a non-default `nn.init` and a `dataset.num_classes`-sized input that a YAML-only config can't express two levels deep.
- Include the loss's own learnable parameters in the optimizer -- previously only the backbone was optimized, so `VOSRegLoss`'s weighted-energy/logistic-regression heads silently never trained. (Confirmed this was a real bug: a first training run without this fix produced badly inverted energy-based OOD scores; re-training with the fix gave sane, improved results.)
- Persist the fitted `weights_energy`/`logistic_regression` alongside the checkpoint (`criterion.pt`), so the model can later be scored with `WeightedEBO`, the paper's own detector.

## Test plan
- [x] Trained end-to-end on CIFAR-10 (3 seeds), CIFAR-100 (3 seeds), and ImageNet-200 (1 seed)
- [x] Evaluated against the crossentropy baseline: VOS consistently improved MaxSoftmax/MaxLogit/EnergyBased/WeightedEBO OOD detection with no accuracy regression