### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'pytorch-ood: A Unified PyTorch Library for Out-of-Distribution Detection'
+type: software
+authors:
+- given-names: Konstantin
+  family-names: Kirchheim
+  orcid: https://orcid.org/0000-0001-5819-7692
+- given-names: Theo
+  family-names: Langer
+  orcid: https://orcid.org/0009-0001-9393-4747
+- given-names: Frank
+  family-names: Ortmeier
+  orcid: https://orcid.org/0000-0001-6186-4142
+repository-code: https://github.com/kkirchheim/pytorch-ood
+license: Apache-2.0


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.