### PR TITLE
docs: add explicit user support routes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report incorrect or broken behavior in PyTorch-OOD
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Search existing issues before submitting a duplicate report.
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: Clearly describe the problem and the observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Explain what you expected to happen.
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Package versions
+      description: Provide the PyTorch-OOD, Python, PyTorch, and torchvision versions.
+      placeholder: "pytorch-ood 0.3.2, Python 3.12, torch 2.7, torchvision 0.22"
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform and device
+      description: Provide the operating system and device in use (CPU, CUDA, or MPS).
+      placeholder: "Ubuntu 24.04, CUDA 12.8, NVIDIA RTX 4090"
+    validations:
+      required: true
+  - type: input
+    id: installation
+    attributes:
+      label: Installation method
+      description: Explain how PyTorch-OOD and its dependencies were installed.
+      placeholder: "pip install pytorch-ood"
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Provide the smallest self-contained code example that reproduces the problem.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Complete error output
+      description: Include the complete, unedited error output or traceback.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other information that may help diagnose the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PyTorch-OOD documentation
+    url: https://pytorch-ood.readthedocs.io/en/latest/
+    about: Check the documentation before opening a support request.

--- a/.github/ISSUE_TEMPLATE/usage-question.yml
+++ b/.github/ISSUE_TEMPLATE/usage-question.yml
@@ -1,0 +1,60 @@
+name: Usage question
+description: Ask for help using PyTorch-OOD
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for using PyTorch-OOD. Search the documentation and existing issues before submitting a question.
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Explain what you are trying to achieve and where you need help.
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Package versions
+      description: Provide the PyTorch-OOD, Python, PyTorch, and torchvision versions.
+      placeholder: "pytorch-ood 0.3.2, Python 3.12, torch 2.7, torchvision 0.22"
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform and device
+      description: Provide the operating system and device in use (CPU, CUDA, or MPS).
+      placeholder: "Ubuntu 24.04, CUDA 12.8, NVIDIA RTX 4090"
+    validations:
+      required: true
+  - type: input
+    id: installation
+    attributes:
+      label: Installation method
+      description: Explain how PyTorch-OOD and its dependencies were installed.
+      placeholder: "pip install pytorch-ood"
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Provide the smallest self-contained code example that demonstrates the question.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Complete output
+      description: Include the complete, unedited error output or traceback, if applicable.
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other information that may help answer the question.

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,18 @@ The documentation is available `here <https://pytorch-ood.readthedocs.io/en/late
 that should be larger for outliers than for inliers.
 If you notice that the scores predicted by a detector do not match the formulas in the corresponding publication, we may have adjusted the score calculation to comply with this convention.
 
+💬  Getting Help
+^^^^^^^^^^^^^^^^^
+
+* For questions about using PyTorch-OOD, open a `usage support request <https://github.com/kkirchheim/pytorch-ood/issues/new?template=usage-question.yml>`_.
+* To report incorrect or broken behavior, open a `bug report <https://github.com/kkirchheim/pytorch-ood/issues/new?template=bug-report.yml>`_.
+* To propose or contribute changes, read the `contribution guidelines <CONTRIBUTING.md>`_.
+
+Before requesting support, please check the `documentation <https://pytorch-ood.readthedocs.io/en/latest/>`_
+and existing `issues <https://github.com/kkirchheim/pytorch-ood/issues>`_. Include the PyTorch-OOD,
+Python, and PyTorch versions, your platform and device, a minimal reproducer, and the complete error output.
+See the `support guide <https://pytorch-ood.readthedocs.io/en/latest/support.html>`_ for details.
+
 ⏳ Quick Start
 ^^^^^^^^^^^^^^^^^
 Load a WideResNet-40 model (used in major publications), pre-trained on CIFAR-10 with the Energy-Bounded Learning Loss [#EnergyBasedOOD]_ (weights from to original paper), and predict on some dataset ``data_loader`` using
@@ -416,7 +428,7 @@ If you use this project, please cite:
 🤝  Contributing
 ^^^^^^^^^^^^^^^^^
 We encourage everyone to contribute to this project by adding implementations of OOD Detection methods, datasets etc,
-or check the existing implementations for bugs.
+or check the existing implementations for bugs. See the `contribution guidelines <CONTRIBUTING.md>`_ to get started.
 
 
 🛡️ ️License

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ nomenclature, and structured API documentation.
    :caption: Overview
 
    info
+   support
 
 .. toctree::
    :maxdepth: 2

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,0 +1,27 @@
+Support
+*******
+
+PyTorch-OOD uses public GitHub routes for support, defect reports, and
+contributions. Please choose the route that best matches your request:
+
+* For help using the library, open a `usage support request <https://github.com/kkirchheim/pytorch-ood/issues/new?template=usage-question.yml>`_.
+* For incorrect or broken behavior, open a `bug report <https://github.com/kkirchheim/pytorch-ood/issues/new?template=bug-report.yml>`_.
+* To propose or contribute a change, follow the `contribution guidelines <https://github.com/kkirchheim/pytorch-ood/blob/dev/CONTRIBUTING.md>`_.
+
+Before opening a request
+========================
+
+Search the documentation and existing issues first. When requesting support
+or reporting a defect, include:
+
+* the PyTorch-OOD version;
+* the Python, PyTorch, and torchvision versions;
+* the operating system and relevant device information (CPU, CUDA, or MPS);
+* the installation method;
+* a minimal, self-contained reproducer;
+* the expected and observed behavior; and
+* the complete, unedited error output or traceback.
+
+Remove credentials and other sensitive information before posting. Requests
+without enough information to reproduce or understand the problem may require
+additional details before they can be addressed.


### PR DESCRIPTION
Addresses issue #167 by adding explicit routes for user support to documentation and readme 